### PR TITLE
Make the timestamp field configurable

### DIFF
--- a/lib/logstash/outputs/graphite.rb
+++ b/lib/logstash/outputs/graphite.rb
@@ -51,6 +51,11 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
   # Exclude regex matched metric names, by default exclude unresolved %{field} strings.
   config :exclude_metrics, :validate => :array, :default => [ "%\{[^}]+\}" ]
 
+  # Use this field for the timestamp instead of '@timestamp' which is the
+  # default. Useful when backfilling or just getting more accurate data into
+  # graphite since you probably have a cache layer infront of Logstash.
+  config :timestamp_field, :validate => :string, :default => '@timestamp'
+
   # Enable debug output.
   config :debug, :validate => :boolean, :default => false, :deprecated => "This setting was never used by this plugin. It will be removed soon."
 
@@ -102,7 +107,7 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
     # Graphite message format: metric value timestamp\n
 
     messages = []
-    timestamp = event.sprintf("%{+%s}")
+    timestamp = event[@timestamp_field].to_i
 
     if @fields_are_metrics
       @logger.debug("got metrics event", :metrics => event.to_hash)

--- a/logstash-output-graphite.gemspec
+++ b/logstash-output-graphite.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'
   s.add_development_dependency 'logstash-filter-kv'
+  s.add_development_dependency 'logstash-filter-ruby'
 end
 

--- a/spec/outputs/graphite_spec.rb
+++ b/spec/outputs/graphite_spec.rb
@@ -248,4 +248,40 @@ describe LogStash::Outputs::Graphite do
     end
   end
 
+  context "timestamp_field used is timestamp_new" do
+    timestamp_new = (Time.now + 3).to_i
+    let(:config) do <<-CONFIG
+          input {
+            generator {
+              message => "foo=123"
+              count => 1
+              type => "generator"
+            }
+          }
+
+          filter {
+            ruby {
+              code => "event['timestamp_new'] = Time.at(#{timestamp_new})"
+            }
+          }
+
+          output {
+            graphite {
+                host => "localhost"
+                port => #{port}
+                timestamp_field => "timestamp_new"
+                metrics => ["foo", "1"]
+                debug => true
+            }
+          }
+    CONFIG
+    end
+
+    it "timestamp matches timestamp_new" do
+      lines = server.pop
+      expect(lines).to match(/^foo 1.0 #{timestamp_new}\n$/)
+    end
+
+  end
+
 end


### PR DESCRIPTION
Make it possible to use a field, e.g. @timestamp, for metrics sent to
Graphite instead of current timestamp. Useful when backfilling or
getting nice and complete graphs.

Thanks to @mfournier for encouraging me to submit this PR.
