### PR TITLE
ensure mock server replies recently written messages

### DIFF
--- a/spec/outputs/graphite_spec.rb
+++ b/spec/outputs/graphite_spec.rb
@@ -3,208 +3,107 @@ require_relative '../spec_helper'
 describe LogStash::Outputs::Graphite do
 
   let(:port) { 4939 }
-  let(:config) do <<-CONFIG
-     input {
-        generator {
-          message => "foo=fancy bar=42"
-          count => 1
-          type => "generator"
-        }
-      }
+  let(:server) { subject.socket }
 
-      filter {
-        kv { }
-      }
-
-      output {
-        graphite {
-          host => "localhost"
-          port => #{port}
-          metrics => [ "hurray.%{foo}", "%{bar}" ]
-        }
-      }
-  CONFIG
-  end
-
-  let(:pipeline) { LogStash::Pipeline.new(config) }
-  let(:server)   { Mocks::Server.new(port) }
-
-  before do
-    server.start
-    pipeline.run
-  end
-
-  after do
-    server.stop
+  before :each do
+    subject.register
+    subject.receive(event)
   end
 
   context "with a default run" do
+
+    subject { LogStash::Outputs::Graphite.new("host" => "localhost", "port" => port, "metrics" => [ "hurray.%{foo}", "%{bar}" ]) }
+    let(:event) { LogStash::Event.new("foo" => "fancy", "bar" => 42) }
 
     it "generate one element" do
       expect(server.size).to eq(1)
     end
 
     it "include all metrics" do
-      lines = server.pop
-      expect(lines).to match(/^hurray.fancy 42.0 \d{10,}\n$/)
+      line = server.pop
+      expect(line).to match(/^hurray.fancy 42.0 \d{10,}\n$/)
     end
-
   end
 
   context "if fields_are_metrics => true" do
     context "when metrics_format => ..." do
+      subject { LogStash::Outputs::Graphite.new("host" => "localhost",
+                                                      "port" => port,
+                                                      "fields_are_metrics" => true,
+                                                      "include_metrics" => ["foo"],
+                                                      "metrics_format" => "foo.bar.sys.data.*") }
+
+      let(:event) { LogStash::Event.new("foo" => "123") }
 
       context "match one key" do
-        let(:config) do <<-CONFIG
-          input {
-            generator {
-              message => "foo=123"
-              count => 1
-              type => "generator"
-            }
-          }
-
-          filter {
-            kv { }
-          }
-
-          output {
-            graphite {
-                host => "localhost"
-                port => #{port}
-                fields_are_metrics => true
-                include_metrics => ["foo"]
-                metrics_format => "foo.bar.sys.data.*"
-                debug => true
-            }
-          }
-        CONFIG
-        end
-
         it "generate one element" do
           expect(server.size).to eq(1)
         end
 
         it "match the generated key" do
-          lines = server.pop
-          expect(lines).to match(/^foo.bar.sys.data.foo 123.0 \d{10,}\n$/)
-        end
-
-      end
-
-      context "match all keys" do
-
-        let(:config) do <<-CONFIG
-          input {
-            generator {
-              message => "foo=123 bar=42"
-              count => 1
-              type => "generator"
-            }
-          }
-
-          filter {
-            kv { }
-          }
-
-          output {
-            graphite {
-                host => "localhost"
-                port => #{port}
-                fields_are_metrics => true
-                include_metrics => [".*"]
-                metrics_format => "foo.bar.sys.data.*"
-                debug => true
-            }
-          }
-        CONFIG
-        end
-
-        let(:lines) do
-          dict = {}
-          while(!server.empty?)
-            line = server.pop
-            key  = line.split(' ')[0]
-            dict[key] = line
-          end
-          dict
-        end
-
-        it "match the generated foo key" do
-          expect(lines['foo.bar.sys.data.foo']).to match(/^foo.bar.sys.data.foo 123.0 \d{10,}\n$/)
-        end
-
-        it "match the generated bar key" do
-          expect(lines['foo.bar.sys.data.bar']).to match(/^foo.bar.sys.data.bar 42.0 \d{10,}\n$/)
-        end
-
-      end
-
-      context "no match" do
-
-        let(:config) do  <<-CONFIG
-          input {
-            generator {
-              message => "foo=123 bar=42"
-              count => 1
-              type => "generator"
-            }
-          }
-
-          filter {
-            kv { }
-          }
-
-          output {
-            graphite {
-              host => "localhost"
-              port => #{port}
-              fields_are_metrics => true
-              include_metrics => ["notmatchinganything"]
-              metrics_format => "foo.bar.sys.data.*"
-              debug => true
-            }
-          }
-        CONFIG
-        end
-
-        it "generate no event" do
-          expect(server.empty?).to eq(true)
+          line = server.pop
+          expect(line).to match(/^foo.bar.sys.data.foo 123.0 \d{10,}\n$/)
         end
       end
+    end
 
-      context "match a key with invalid metric_format" do
+    context "match all keys" do
 
-        let(:config) do <<-CONFIG
-          input {
-            generator {
-              message => "foo=123"
-              count => 1
-              type => "generator"
-            }
-          }
+      subject { LogStash::Outputs::Graphite.new("host" => "localhost",
+                                                      "port" => port,
+                                                      "fields_are_metrics" => true,
+                                                      "include_metrics" => [".*"],
+                                                      "metrics_format" => "foo.bar.sys.data.*") }
 
-          filter {
-            kv { }
-          }
+      let(:event) { LogStash::Event.new("foo" => "123", "bar" => "42") }
 
-          output {
-            graphite {
-                host => "localhost"
-                port => #{port}
-                fields_are_metrics => true
-                include_metrics => ["foo"]
-                metrics_format => "invalidformat"
-                debug => true
-            }
-          }
-        CONFIG
+      let(:lines) do
+        dict = {}
+        while(!server.empty?)
+          line = server.pop
+          key  = line.split(' ')[0]
+          dict[key] = line
         end
+        dict
+      end
 
-        it "match the foo key" do
-          lines = server.pop
-          expect(lines).to match(/^foo 123.0 \d{10,}\n$/)
-        end
+      it "match the generated foo key" do
+        expect(lines['foo.bar.sys.data.foo']).to match(/^foo.bar.sys.data.foo 123.0 \d{10,}\n$/)
+      end
+
+      it "match the generated bar key" do
+        expect(lines['foo.bar.sys.data.bar']).to match(/^foo.bar.sys.data.bar 42.0 \d{10,}\n$/)
+      end
+    end
+
+    context "no match" do
+
+      subject { LogStash::Outputs::Graphite.new("host" => "localhost",
+                                                      "port" => port,
+                                                      "fields_are_metrics" => true,
+                                                      "include_metrics" => ["notmatchinganything"],
+                                                      "metrics_format" => "foo.bar.sys.data.*") }
+
+      let(:event) { LogStash::Event.new("foo" => "123", "bar" => "42") }
+
+      it "generate no event" do
+        expect(server.empty?).to eq(true)
+      end
+    end
+
+    context "match a key with invalid metric_format" do
+
+      subject { LogStash::Outputs::Graphite.new("host" => "localhost",
+                                                      "port" => port,
+                                                      "fields_are_metrics" => true,
+                                                      "include_metrics" => ["foo"],
+                                                      "metrics_format" => "invalidformat") }
+
+      let(:event) { LogStash::Event.new("foo" => "123") }
+
+      it "match the foo key" do
+        line = server.pop
+        expect(line).to match(/^foo 123.0 \d{10,}\n$/)
       end
     end
   end
@@ -213,75 +112,36 @@ describe LogStash::Outputs::Graphite do
     context "metrics_format not set" do
       context "match one key with metrics list" do
 
-        let(:config) do <<-CONFIG
-          input {
-            generator {
-              message => "foo=123"
-              count => 1
-              type => "generator"
-            }
-          }
+        subject { LogStash::Outputs::Graphite.new("host" => "localhost",
+                                                        "port" => port,
+                                                        "fields_are_metrics" => false,
+                                                        "include_metrics" => ["foo"],
+                                                        "metrics" => [ "custom.foo", "%{foo}" ]) }
 
-          filter {
-            kv { }
-          }
-
-          output {
-            graphite {
-                host => "localhost"
-                port => #{port}
-                fields_are_metrics => false
-                include_metrics => ["foo"]
-                metrics => [ "custom.foo", "%{foo}" ]
-                debug => true
-            }
-          }
-        CONFIG
-        end
+        let(:event) { LogStash::Event.new("foo" => "123") }
 
         it "match the custom.foo key" do
-          lines = server.pop
-          expect(lines).to match(/^custom.foo 123.0 \d{10,}\n$/)
+          line = server.pop
+          expect(line).to match(/^custom.foo 123.0 \d{10,}\n$/)
         end
-
       end
     end
   end
 
   context "timestamp_field used is timestamp_new" do
-    timestamp_new = (Time.now + 3).to_i
-    let(:config) do <<-CONFIG
-          input {
-            generator {
-              message => "foo=123"
-              count => 1
-              type => "generator"
-            }
-          }
 
-          filter {
-            ruby {
-              code => "event['timestamp_new'] = Time.at(#{timestamp_new})"
-            }
-          }
+    let(:timestamp_new) { (Time.now + 3).to_i }
 
-          output {
-            graphite {
-                host => "localhost"
-                port => #{port}
-                timestamp_field => "timestamp_new"
-                metrics => ["foo", "1"]
-                debug => true
-            }
-          }
-    CONFIG
-    end
+    subject { LogStash::Outputs::Graphite.new("host" => "localhost",
+                                                    "port" => port,
+                                                    "timestamp_field" => "timestamp_new",
+                                                    "metrics" => ["foo", "1"]) }
+
+    let(:event) { LogStash::Event.new("foo" => "123", "timestamp_new" => timestamp_new) }
 
     it "timestamp matches timestamp_new" do
-      lines = server.pop
-      expect(lines).to match(/^foo 1.0 #{timestamp_new}\n$/)
+      line = server.pop
+      expect(line).to match(/^foo 1.0 #{timestamp_new}\n$/)
     end
-
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,11 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/graphite"
 require_relative "support/server"
+
+class LogStash::Outputs::Graphite
+  attr_reader :socket
+
+  def connect
+    @socket = Mocks::Server.new
+  end
+end

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,24 +1,8 @@
 module Mocks
   class Server
 
-    def initialize(port)
-      @queue = Queue.new
-      @port  = port
-    end
-
-    def start
-      @server = TCPServer.new("127.0.0.1", @port)
-      @queue.clear
-      Thread.new do
-        client = @server.accept
-        while true
-          if !client.eof?
-            line = client.readline
-            @queue << line
-          end
-        end
-      end
-      self
+    def initialize
+      @queue = Array.new
     end
 
     def size
@@ -30,12 +14,16 @@ module Mocks
     end
 
     def stop
-      @server.close
     end
 
     def empty?
       @queue.empty?
     end
 
+    def puts(data)
+      data.split("\n").each do |line|
+        @queue << "#{line}\n"
+      end
+    end
   end
 end


### PR DESCRIPTION
some tests were failing because the test flow is:
1. start mock server
2. start graphite output
3. write message to output.receive
4. read messages from mock server

Sometimes output.receive will return faster than mock server is able to pull the message from the socket and push it into its internal queue. This PR introduces a delay for all read operations on the @queue object.
