### PR TITLE
Fix specs around sprintf testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
+- 1.0.2
+  * Added support for sprintf in field formatting
 - 1.0.1
   * Added support for nested hashes as values

--- a/logstash-output-graphite.gemspec
+++ b/logstash-output-graphite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-graphite'
-  s.version         = '1.0.1'
+  s.version         = '1.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output allows you to pull metrics from your logs and ship them to Graphite"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/graphite_spec.rb
+++ b/spec/outputs/graphite_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::Outputs::Graphite do
                                                       "metrics_format" => "foo.%{@host}.sys.data.*") }
 
       let(:event) { LogStash::Event.new("foo" => "123", "@host" => "testhost") }
-      let(:expected_metric_prefix) { "foo.#{event['@host']}.sys.data.foo" }
+      let(:expected_metric_prefix) { "foo.#{event['@host']}.sys.data" }
 
       context "match one key" do
         it "should generate one element" do
@@ -43,7 +43,7 @@ describe LogStash::Outputs::Graphite do
 
         it "should match the generated key" do
           line = server.pop
-          expect(line).to match(/^#{expected_metric_name} 123.0 \d{10,}\n$/)
+          expect(line).to match(/^#{expected_metric_prefix}.foo 123.0 \d{10,}\n$/)
         end
       end
 
@@ -52,8 +52,8 @@ describe LogStash::Outputs::Graphite do
 
         it "should create the proper formatted lines" do
           lines = [server.pop, server.pop].sort # Put key 'a' first
-          expect(lines[0]).to match(/^foo.#{event['@host']}.sys.data.foo.a 3 \d{10,}\n$/)
-          expect(lines[1]).to match(/^foo.#{event['@host']}.sys.data.foo.c.d 2 \d{10,}\n$/)
+          expect(lines[0]).to match(/^#{expected_metric_prefix}.foo.a 3 \d{10,}\n$/)
+          expect(lines[1]).to match(/^#{expected_metric_prefix}.foo.c.d 2 \d{10,}\n$/)
         end
       end
     end


### PR DESCRIPTION
This fixes a spec failure in #16 that wasn't caught because jenkins isn't putting test results into PRs correctly.
