### PR TITLE
remove nil messages 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+## 2.0.3
+ - Fixed empty/nil messages handling
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 
-- 1.0.2
-  * Added support for sprintf in field formatting
-- 1.0.1
-  * Added support for nested hashes as values
+## 1.0.2
+ - Added support for sprintf in field formatting
+
+## 1.0.1
+ - Added support for nested hashes as values

--- a/logstash-output-graphite.gemspec
+++ b/logstash-output-graphite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-graphite'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output allows you to pull metrics from your logs and ship them to Graphite"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/graphite_spec.rb
+++ b/spec/outputs/graphite_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require_relative '../spec_helper'
 
 describe LogStash::Outputs::Graphite do


### PR DESCRIPTION
- code cleanups
- remove nil messages using `compact`
- add encoding header in specs

relates to elastic/logstash#4264 and elastic/logstash#4191

[edit] 
More precisely the problem here is that the order of the `event.to_hash.flat_map` is different in the Java Event implementation than in Ruby, in one case it was outputting `["foo", nil, nil, nil]` while in Java it was `[nil, "foo", nil, nil]` and the `join("\n")` resulted in sending a first `\n` with the Java Event which created 2 graphite messages and the spec expected 1:

```
Failures:

  1) LogStash::Outputs::Graphite if fields_are_metrics => true when metrics_format => ... match one key should generate one element
     Failure/Error: expect(server.size).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # /Users/colin/dev/src/elasticsearch/logstash-plugins/logstash-output-graphite/spec/outputs/graphite_spec.rb:42:in `(root)'
     # ./vendor/bundle/jruby/1.9/gems/rspec-wait-0.0.8/lib/rspec/wait.rb:46:in `(root)'
     # ./lib/bootstrap/rspec.rb:11:in `(root)'
```

Obviously here it just showed that superflous `nil` values were not purged from the messages and the fix is to call `compact` on the messages array.
