### PR TITLE
Addition of a resend_attempts counter to prevent output worker blocking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+ - Preventing output blocking when the graphite server is down by introducing a resend_attempts counter.
+
 ## 2.0.3
  - Fixed empty/nil messages handling
 

--- a/logstash-output-graphite.gemspec
+++ b/logstash-output-graphite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-graphite'
-  s.version         = '2.0.3'
+  s.version         = '2.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output allows you to pull metrics from your logs and ship them to Graphite"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Preventing output blocking when the graphite server is offline by introducing a resend_attempts counter.

TLDR: This patch adds a resend_attempts option that ensures that metrics are discarded after a 3 failed attempts, or by whatever number is defined by the user in the logstash configuration.

There is is a problem with the previous logstash-output-graphite plugin that if the resend_on_failure was enabled and the graphite server went offline, logstash would infinitely attempt to resend metrics and end up blocking logstashs single output worker entirely (meaning logstash processed logs could not reach elasticsearch).  Given that in some business environments graphites metrics are not considered vital, the option for discarding metrics after a few attempts is often considered acceptable, compared to lost or delayed logstash processed logs.

This could even result in logstash crashing as both logs and metrics get held in memory awaiting to be outputted by the now blocked single output worker.  This issue would cause back pressure to the logstash-forwarder clients sending logs to logstash.  This problem could compound with logstashs own logs becoming filled with millions of back pressure warnings until all local file storage is consumed. 

I would also be argue that since the logstash metrics are not time stamped when sent to graphite, the discarding of stale metrics is far more favourable than having a large backlog of stale metrics being dumped in to graphite in a small window of time once the graphite server does come back online.  Because graphite has a metric storage resolution/retention policy, a large surge/backlog of the same metric arriving from logstash within a window smaller than the resolution/retention policy, will simply mean the metrics get discarded anyway.

We have tested this extensively on logstash v1.5.4-1 and found logstash to be considerably more stable.

The resend_attempts option works well with a reduced reconnect_interval setting too, for example:
   reconnect_interval => 1
   resend_attempts => 3
   resend_on_failure => true

Note: I will create another PR in the future to deal with the other logstash-output-graphite problem where logstash cannot start without being able to connect to a working graphite server.
