### PR TITLE
catch unexpected exceptions during socket write and reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.6
+  - Fixed exception handling during socket writing to prevent logstash termination [#33](https://github.com/logstash-plugins/logstash-output-graphite/pull/33)
+
 ## 3.1.5
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/outputs/graphite.rb
+++ b/lib/logstash/outputs/graphite.rb
@@ -130,7 +130,12 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
       begin
         @socket.puts(message)
       rescue Errno::EPIPE, Errno::ECONNRESET, IOError => e
-        @logger.warn("Connection to graphite server died", :exception => e, :host => @host, :port => @port)
+        @logger.warn("Connection to graphite server died", :exception => e.class, :message => e.message, :host => @host, :port => @port)
+        sleep(@reconnect_interval)
+        connect
+        retry if @resend_on_failure
+      rescue => e
+        @logger.warn("Failed to send data", :exception => e.class, :message => e.message, :host => @host, :port => @port)
         sleep(@reconnect_interval)
         connect
         retry if @resend_on_failure

--- a/logstash-output-graphite.gemspec
+++ b/logstash-output-graphite.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-graphite'
-  s.version         = '3.1.5'
+  s.version         = '3.1.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Writes metrics to Graphite"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
we don't know what other possible exceptions may come from TCPSocket#puts, so there should be a safeguard that also retries to connect and retries to send if configured.

The lack of this safety net will bubble the exception outside of the plugin instance and cause logstash to terminate abruptly.

fixes #32