### PR TITLE
Fix registration if Graphite endpoint not reachable

### DIFF
--- a/lib/logstash/outputs/graphite.rb
+++ b/lib/logstash/outputs/graphite.rb
@@ -93,7 +93,7 @@ class LogStash::Outputs::Graphite < LogStash::Outputs::Base
     # TODO(sissel): Test error cases. Catch exceptions. Find fortune and glory. Retire to yak farm.
     begin
       @socket = TCPSocket.new(@host, @port)
-    rescue Errno::ECONNREFUSED => e
+    rescue Errno::ECONNREFUSED, SocketError => e
       @logger.warn("Connection refused to graphite server, sleeping...", :host => @host, :port => @port)
       sleep(@reconnect_interval)
       retry


### PR DESCRIPTION
It might happen that the Graphite endpoint is currently not reachable
but might get back soon. We do not want to throw an error so that
Logstash gets exited and we would need to restart.
Restarting Logstash might let automated deployments fail although
everything is fine so far.